### PR TITLE
support time-map output_format

### DIFF
--- a/R/time_map.R
+++ b/R/time_map.R
@@ -9,6 +9,7 @@
 #' @param arrival_searches One or more objects created by \code{\link{make_search}}
 #' @param unions One or more objects created by \code{\link{make_union_intersect}}
 #' @param intersections One or more objects created by \code{\link{make_union_intersect}}
+#' @param format time-map response format. See \url{https://docs.traveltime.com/api/reference/isochrones#Response-Body} for details.
 #'
 #' @return API response parsed as a list and as a raw json
 #' @export
@@ -54,7 +55,12 @@
 #'     intersections = intersection
 #'   )
 #'}
-time_map <- function(departure_searches = NULL, arrival_searches = NULL, unions = NULL, intersections = NULL) {
+time_map <- function(
+  departure_searches = NULL,
+  arrival_searches = NULL,
+  unions = NULL,
+  intersections = NULL,
+  format = NULL) {
 
   if((is.null(departure_searches) && is.null(arrival_searches))) {
     stop("At least one of arrival_searches/departure_searches required!")
@@ -66,7 +72,5 @@ time_map <- function(departure_searches = NULL, arrival_searches = NULL, unions 
     unions = unions,
     intersections = intersections)
 
-  traveltime_api(path = 'time-map', body = build_body(body))
+  traveltime_api(path = 'time-map', body = build_body(body), format = format)
 }
-
-

--- a/man/time_map.Rd
+++ b/man/time_map.Rd
@@ -8,7 +8,8 @@ time_map(
   departure_searches = NULL,
   arrival_searches = NULL,
   unions = NULL,
-  intersections = NULL
+  intersections = NULL,
+  format = NULL
 )
 }
 \arguments{
@@ -19,6 +20,8 @@ time_map(
 \item{unions}{One or more objects created by \code{\link{make_union_intersect}}}
 
 \item{intersections}{One or more objects created by \code{\link{make_union_intersect}}}
+
+\item{format}{time-map response format. See \url{https://docs.traveltime.com/api/reference/isochrones#Response-Body} for details.}
 }
 \value{
 API response parsed as a list and as a raw json


### PR DESCRIPTION
Add `Accept` header to time-map.

Introduced a new response property `contentRaw` for XML case.  Slightly moved up the error handling in the client prior to parsing response to JSON. If response is not JSON its returned as raw content.

Behaviour:

- return response in requested format when header is present
- return response in default format if header is not present
- return response in default format if header is invalid
- api error if requested unsupported format

See some examples bellow:

XML: 
![image](https://user-images.githubusercontent.com/59711277/197765305-463bf72f-5f64-4fd0-8200-330a0dad65a3.png)

geo+json:
![image](https://user-images.githubusercontent.com/59711277/197768781-d47f16a4-1d28-4242-adbf-939883fbc056.png)

random: 
![image](https://user-images.githubusercontent.com/59711277/197768842-2119de03-698e-4e8b-939a-a5d7b28721c6.png)

undefined: 
![image](https://user-images.githubusercontent.com/59711277/197768911-8938b895-7611-4f21-9a7a-342c2a6b82b3.png)

unsupported:
![image](https://user-images.githubusercontent.com/59711277/197768945-74cf8d10-68d8-449c-aa89-28dd75728d10.png)

Other endpoints are tested and not impacted.