### PR TITLE
revert user agent

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -14,7 +14,7 @@ build_body <- function(body) {
 }
 
 get_ua <- function() {
-  httr::user_agent(paste("Travel Time R SDK", packageVersion("traveltimeR")))
+  httr::user_agent("Travel Time R SDK")
 }
 
 get_api_headers <- function(format = NULL, contentType = NULL) {


### PR DESCRIPTION
This is not a reliable method, as during cran validation the package itself is not actually installed and thus we are failing. We'll need to investigate into a more reliable method to access the version info at runtime or put this on indefinite hold.